### PR TITLE
added Vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ override.tf.json
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
 
+vault.keys
 /images

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Hashistack
-![](https://img.shields.io/badge/Implemented-Terraform-green) ![](https://img.shields.io/badge/Implemented-Nomad-green) ![](https://img.shields.io/badge/Implemented-Consul-green) ![](https://img.shields.io/badge/Implemented-Vault-red)
+![](https://img.shields.io/badge/Implemented-Terraform-green) ![](https://img.shields.io/badge/Implemented-Nomad-green) ![](https://img.shields.io/badge/Implemented-Consul-green) ![](https://img.shields.io/badge/Implemented-Vault-green)
 
-## From Terraform to Nomad with Consul
-This repository aims at automating a Hashicorp Nomad cluster including a Consul cluster with Terraform. 
+## From Terraform to Nomad with Consul and Vault
+This repository aims at automating a Hashicorp Nomad cluster including a Consul and Vault cluster using Terraform. 
 
 It's highly customizable. It will use the libvirt terraform provider to create virtual machines that then installs the software. You can choose the number of server and clients and what Nomad drivers to install ("docker", "local_exec", "raw_exec", "java"] and it will do that for you.
 

--- a/examples/hashicorp/traefik-lb.hcl
+++ b/examples/hashicorp/traefik-lb.hcl
@@ -10,7 +10,9 @@ job "traefik" {
       port "http" {
         static = 8080
       }
-
+      port "https" {
+        static = 8443
+      }
       port "api" {
         static = 8081
       }
@@ -42,21 +44,22 @@ job "traefik" {
 
       template {
         data = <<EOF
+[serversTransport]
+  insecureSkipVerify = true
 [entryPoints]
     [entryPoints.http]
     address = ":8080"
+    [entryPoints.https]
+    address = ":8443"
     [entryPoints.traefik]
     address = ":8081"
-
 [api]
     dashboard = true
     insecure  = true
-
 # Enable Consul Catalog configuration backend.
 [providers.consulCatalog]
     prefix           = "traefik"
     exposedByDefault = false
-
     [providers.consulCatalog.endpoint]
       address = "127.0.0.1:8500"
       scheme  = "http"

--- a/examples/hashicorp/traefik-lb.hcl
+++ b/examples/hashicorp/traefik-lb.hcl
@@ -11,7 +11,7 @@ job "traefik" {
         static = 8080
       }
       port "https" {
-        static = 8443
+        static = 443
       }
       port "api" {
         static = 8081
@@ -50,7 +50,7 @@ job "traefik" {
     [entryPoints.http]
     address = ":8080"
     [entryPoints.https]
-    address = ":8443"
+    address = ":443"
     [entryPoints.traefik]
     address = ":8081"
 [api]

--- a/scripts/vault-unseal.sh
+++ b/scripts/vault-unseal.sh
@@ -6,12 +6,13 @@
 #echo "Vault IP: $VAULT_IP"
 #echo $VAULT_KEYS
 
+VAULT_SCHEME="https"
 VAULT_PORT="8200"
-UNSEAL_KEYS=$(echo $VAULT_KEYS | jq -r '.keys[]' )
+UNSEAL_KEYS=$(cat $VAULT_KEYS | jq -r '.keys[]' )
 
 if [ ! -z "$VAULT_KEYS" ] && [ ! -z "$VAULT_IP" ];then
   while IFS= read -r line; do
-    $("vault operator unseal --tls-skip-verify https://${VAULT_IP} $line")
+    vault operator unseal --tls-skip-verify -address=${VAULT_SCHEME}://${VAULT_IP}:$VAULT_PORT $line
   done <<< "$UNSEAL_KEYS"
 else
   echo "Variable VAULT_KEYS OR VAULT_IP is empty!"

--- a/scripts/vault-unseal.sh
+++ b/scripts/vault-unseal.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Vault IP: $VAULT_IP"
+echo $VAULT_KEYS

--- a/scripts/vault-unseal.sh
+++ b/scripts/vault-unseal.sh
@@ -2,9 +2,9 @@
 
 VAULT_SCHEME="https"
 VAULT_PORT="8200"
-UNSEAL_KEYS=$(cat $VAULT_KEYS | jq -r '.keys[]' )
 
 if [ ! -z "$VAULT_KEYS" ] && [ ! -z "$VAULT_IP" ];then
+  UNSEAL_KEYS=$(cat $VAULT_KEYS | jq -r '.keys[]' )
   while IFS= read -r line; do
     eval curl --verbose --request PUT --insecure --data "'{\"key\": \"$line\"}'" ${VAULT_SCHEME}://${VAULT_IP}:$VAULT_PORT/v1/sys/unseal
     #vault operator unseal --tls-skip-verify -address=${VAULT_SCHEME}://${VAULT_IP}:$VAULT_PORT $line

--- a/scripts/vault-unseal.sh
+++ b/scripts/vault-unseal.sh
@@ -1,18 +1,13 @@
 #!/bin/bash
 
-#export VAULT_KEYS='{"keys":["860e9f247e992b9f7838251ff0952d8cec5f8ead6fb13543ae13e49b26628ad78e","d06d1b55b98a6178bcc6ca297a42938cfffcc7355419c322a7685c104a7f9f8f9d","5220a0ddf371eefa45344b4bdc0f61a1a29e6975b17f798126309d60cd1cde8ad2","13e12c38c1117d4a967d9abeea9e518783f0619201c09a4816ea3bca59dde84713","c2ae3633efc0e463793a6b76b815c0a1c3d588b63128778ac30c222659fec62030","78291d3915784efe13e523c3c1da27e7ad96f7f2644093dc80f9c0c3a9f0354601","e05336eb1a4d4725dd17d6e41344c2c001d4e2821031c8c321fc239419af80187d","8ba894a66adeeb398fe1bc42e89b16fdd0124b0da698304b025b87b8b8d3333cd8","8fe7d2fe94159e7d32859679a351b53be2e2bc36b97e83a7a868814b07be4cd5cc","da3a6428efcb53d3fafbb0bf07df4c244bc88c7f537a59d06555c07c2c7c9ed453"],"keys_base64":["hg6fJH6ZK594OCUf8JUtjOxfjq1vsTVDrhPkmyZiiteO","0G0bVbmKYXi8xsopekKTjP/8xzVUGcMip2hcEEp/n4+d","UiCg3fNx7vpFNEtL3A9hoaKeaXWxf3mBJjCdYM0c3orS","E+EsOMERfUqWfZq+6p5Rh4PwYZIBwJpIFuo7ylnd6EcT","wq42M+/A5GN5Omt2uBXAocPViLYxKHeKwwwiJln+xiAw","eCkdORV4Tv4T5SPDwdon562W9/JkQJPcgPnAw6nwNUYB","4FM26xpNRyXdF9bkE0TCwAHU4oIQMcjDIfwjlBmvgBh9","i6iUpmre6zmP4bxC6JsW/dASSw2mmDBLAluHuLjTMzzY","j+fS/pQVnn0yhZZ5o1G1O+LivDa5foOnqGiBSwe+TNXM","2jpkKO/LU9P6+7C/B99MJEvIjH9TelnQZVXAfCx8ntRT"],"root_token":"s.60qWf9SzLR4Y3rIJtvmB5TZO"}'
-
-#export VAULT_IP="10.4.5.6:8200"
-#echo "Vault IP: $VAULT_IP"
-#echo $VAULT_KEYS
-
 VAULT_SCHEME="https"
 VAULT_PORT="8200"
 UNSEAL_KEYS=$(cat $VAULT_KEYS | jq -r '.keys[]' )
 
 if [ ! -z "$VAULT_KEYS" ] && [ ! -z "$VAULT_IP" ];then
   while IFS= read -r line; do
-    vault operator unseal --tls-skip-verify -address=${VAULT_SCHEME}://${VAULT_IP}:$VAULT_PORT $line
+    eval curl --verbose --request PUT --insecure --data "'{\"key\": \"$line\"}'" ${VAULT_SCHEME}://${VAULT_IP}:$VAULT_PORT/v1/sys/unseal
+    #vault operator unseal --tls-skip-verify -address=${VAULT_SCHEME}://${VAULT_IP}:$VAULT_PORT $line
   done <<< "$UNSEAL_KEYS"
 else
   echo "Variable VAULT_KEYS OR VAULT_IP is empty!"

--- a/scripts/vault-unseal.sh
+++ b/scripts/vault-unseal.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
 
-echo "Vault IP: $VAULT_IP"
-echo $VAULT_KEYS
+#export VAULT_KEYS='{"keys":["860e9f247e992b9f7838251ff0952d8cec5f8ead6fb13543ae13e49b26628ad78e","d06d1b55b98a6178bcc6ca297a42938cfffcc7355419c322a7685c104a7f9f8f9d","5220a0ddf371eefa45344b4bdc0f61a1a29e6975b17f798126309d60cd1cde8ad2","13e12c38c1117d4a967d9abeea9e518783f0619201c09a4816ea3bca59dde84713","c2ae3633efc0e463793a6b76b815c0a1c3d588b63128778ac30c222659fec62030","78291d3915784efe13e523c3c1da27e7ad96f7f2644093dc80f9c0c3a9f0354601","e05336eb1a4d4725dd17d6e41344c2c001d4e2821031c8c321fc239419af80187d","8ba894a66adeeb398fe1bc42e89b16fdd0124b0da698304b025b87b8b8d3333cd8","8fe7d2fe94159e7d32859679a351b53be2e2bc36b97e83a7a868814b07be4cd5cc","da3a6428efcb53d3fafbb0bf07df4c244bc88c7f537a59d06555c07c2c7c9ed453"],"keys_base64":["hg6fJH6ZK594OCUf8JUtjOxfjq1vsTVDrhPkmyZiiteO","0G0bVbmKYXi8xsopekKTjP/8xzVUGcMip2hcEEp/n4+d","UiCg3fNx7vpFNEtL3A9hoaKeaXWxf3mBJjCdYM0c3orS","E+EsOMERfUqWfZq+6p5Rh4PwYZIBwJpIFuo7ylnd6EcT","wq42M+/A5GN5Omt2uBXAocPViLYxKHeKwwwiJln+xiAw","eCkdORV4Tv4T5SPDwdon562W9/JkQJPcgPnAw6nwNUYB","4FM26xpNRyXdF9bkE0TCwAHU4oIQMcjDIfwjlBmvgBh9","i6iUpmre6zmP4bxC6JsW/dASSw2mmDBLAluHuLjTMzzY","j+fS/pQVnn0yhZZ5o1G1O+LivDa5foOnqGiBSwe+TNXM","2jpkKO/LU9P6+7C/B99MJEvIjH9TelnQZVXAfCx8ntRT"],"root_token":"s.60qWf9SzLR4Y3rIJtvmB5TZO"}'
+
+#export VAULT_IP="10.4.5.6:8200"
+#echo "Vault IP: $VAULT_IP"
+#echo $VAULT_KEYS
+
+VAULT_PORT="8200"
+UNSEAL_KEYS=$(echo $VAULT_KEYS | jq -r '.keys[]' )
+
+if [ ! -z "$VAULT_KEYS" ] && [ ! -z "$VAULT_IP" ];then
+  while IFS= read -r line; do
+    $("vault operator unseal --tls-skip-verify https://${VAULT_IP} $line")
+  done <<< "$UNSEAL_KEYS"
+else
+  echo "Variable VAULT_KEYS OR VAULT_IP is empty!"
+fi

--- a/templates/cloud_init_client.cfg
+++ b/templates/cloud_init_client.cfg
@@ -131,12 +131,6 @@ runcmd:
   # Global update
   - apt-get update
 
-  # Install Nomad section  
-  - sudo apt-get install nomad -y
-  - mkdir --parents /etc/nomad.d && chmod 700 /etc/nomad.d
-  - systemctl enable nomad
-  - systemctl start nomad
-
   # Intall Consul section
   - sudo apt-get install consul -y
   - mkdir --parents /opt/consul
@@ -145,6 +139,12 @@ runcmd:
   - chmod 640 /etc/consul.d/consul.hcl
   - systemctl enable consul
   - systemctl start consul
+  
+  # Install Nomad section  
+  - sudo apt-get install nomad -y
+  - mkdir --parents /etc/nomad.d && chmod 700 /etc/nomad.d
+  - systemctl enable nomad
+  - systemctl start nomad
 
   # Install Docker section
   - ${NOMAD_DRIVER_DOCKER} && sudo apt-get install docker-ce docker-ce-cli containerd.io -y

--- a/templates/cloud_init_client.cfg
+++ b/templates/cloud_init_client.cfg
@@ -69,8 +69,6 @@ write_files:
       }
     path: /etc/nomad.d/client.hcl
 
-  - content: |
-
   - content: | ${CONSUL_AGENT_CA}
     path: /etc/consul.d/consul-agent-ca.pem 
 

--- a/templates/cloud_init_server.cfg
+++ b/templates/cloud_init_server.cfg
@@ -111,6 +111,25 @@ write_files:
       advertise_addr = "${NODE_IP}"
     path: /etc/consul.d/consul.hcl
 
+  - content: |
+      mlock = true
+      listener "tcp" {
+        address          = "0.0.0.0:8200"
+        cluster_address  = "${NODE_IP}:8201"
+        tls_disable      = "false"
+        tls_cert_file    = "/opt/vault/tls/vault.crt"
+        tls_key_file     = "/opt/vault/tls/vault.key"
+      }
+
+      storage "consul" {
+        address = "127.0.0.1:8500"
+        path    = "vault/"
+      }
+      ui = true
+      api_addr =  "http://${NODE_IP}:8200"
+      cluster_addr = "https://${NODE_IP}:8201"
+    path: /etc/vault.d/vault.hcl
+
 runcmd:
   # Init Nomad section
   - curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
@@ -135,6 +154,18 @@ runcmd:
 
   # Global update
   - apt-get update
+
+  # Install Vault section  
+  - sudo apt-get install vault -y
+  - mkdir --parents /etc/vault.d 
+  - chown --recursive vault:vault /etc/vault.d
+  - chmod 700 /etc/vault.d
+  - mkdir --parents /opt/vault/tls/
+  - chown --recursive vault:vault /opt/vault/tls/
+  - chmod 700 /opt/vault/tls/
+  - openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=vault.local" -keyout /opt/vault/tls/vault.key  -out /opt/vault/tls/vault.crt
+  - systemctl enable vault
+  - systemctl start vault
 
   # Install Nomad section  
   - sudo apt-get install nomad -y

--- a/templates/cloud_init_server.cfg
+++ b/templates/cloud_init_server.cfg
@@ -124,7 +124,7 @@ write_files:
       storage "consul" {
         address      = "127.0.0.1:8500"
         path         = "vault/"
-        service_tags = "traefik.enable=true, traefik.http.routers.http.rule=Host(`vault.hashistack.local`), traefik.backend.loadbalancer.stickiness=true, traefik.protocol=https, traefik.http.services.vault.loadbalancer.server.scheme=https"
+        service_tags = "traefik.enable=true, traefik.http.routers.https.tls=true, traefik.http.routers.https.rule=Host(`vault.hashistack.local`), traefik.backend.loadbalancer.stickiness=true, traefik.protocol=https, traefik.http.services.vault.loadbalancer.server.scheme=https"
       }
       ui = true
       api_addr =  "http://${NODE_IP}:8200"

--- a/templates/cloud_init_server.cfg
+++ b/templates/cloud_init_server.cfg
@@ -95,7 +95,7 @@ write_files:
       verify_server_hostname = false
       retry_join = ["${NOMAD_SERVER_JOIN_IP}"]
       server = true
-      bootstrap_expect = 1
+      bootstrap_expect = ${NOMAD_SERVER_COUNT}
       ui = true
       bind_addr = "0.0.0.0"
       client_addr = "0.0.0.0"
@@ -122,8 +122,9 @@ write_files:
       }
 
       storage "consul" {
-        address = "127.0.0.1:8500"
-        path    = "vault/"
+        address      = "127.0.0.1:8500"
+        path         = "vault/"
+        service_tags = "traefik.enable=true, traefik.http.routers.http.rule=Path(`/vault`), traefik.backend.loadbalancer.stickiness=true, traefik.protocol=https, traefik.http.services.vault.loadbalancer.server.scheme=https"
       }
       ui = true
       api_addr =  "http://${NODE_IP}:8200"
@@ -155,6 +156,15 @@ runcmd:
   # Global update
   - apt-get update
 
+  # Intall Consul section
+  - sudo apt-get install consul -y
+  - mkdir --parents /opt/consul
+  - chown --recursive consul:consul /opt/consul
+  - chown --recursive consul:consul /etc/consul.d
+  - chmod 640 /etc/consul.d/consul.hcl
+  - systemctl enable consul
+  - systemctl start consul
+
   # Install Vault section  
   - sudo apt-get install vault -y
   - mkdir --parents /etc/vault.d 
@@ -172,15 +182,6 @@ runcmd:
   - mkdir --parents /etc/nomad.d && chmod 700 /etc/nomad.d
   - systemctl enable nomad
   - systemctl start nomad
-
-  # Intall Consul section
-  - sudo apt-get install consul -y
-  - mkdir --parents /opt/consul
-  - chown --recursive consul:consul /opt/consul
-  - chown --recursive consul:consul /etc/consul.d
-  - chmod 640 /etc/consul.d/consul.hcl
-  - systemctl enable consul
-  - systemctl start consul
 
   # Install Docker section
   - ${NOMAD_SERVER_ENABLE_CLIENT} && ${NOMAD_DRIVER_DOCKER} && sudo apt-get install docker-ce docker-ce-cli containerd.io -y

--- a/templates/cloud_init_server.cfg
+++ b/templates/cloud_init_server.cfg
@@ -161,9 +161,9 @@ runcmd:
   - chown --recursive vault:vault /etc/vault.d
   - chmod 700 /etc/vault.d
   - mkdir --parents /opt/vault/tls/
+  - openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=vault.local" -keyout /opt/vault/tls/vault.key  -out /opt/vault/tls/vault.crt
   - chown --recursive vault:vault /opt/vault/tls/
   - chmod 700 /opt/vault/tls/
-  - openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=vault.local" -keyout /opt/vault/tls/vault.key  -out /opt/vault/tls/vault.crt
   - systemctl enable vault
   - systemctl start vault
 

--- a/templates/cloud_init_server.cfg
+++ b/templates/cloud_init_server.cfg
@@ -124,7 +124,7 @@ write_files:
       storage "consul" {
         address      = "127.0.0.1:8500"
         path         = "vault/"
-        service_tags = "traefik.enable=true, traefik.http.routers.http.rule=Path(`/vault`), traefik.backend.loadbalancer.stickiness=true, traefik.protocol=https, traefik.http.services.vault.loadbalancer.server.scheme=https"
+        service_tags = "traefik.enable=true, traefik.http.routers.http.rule=Host(`vault.hashistack.local`), traefik.backend.loadbalancer.stickiness=true, traefik.protocol=https, traefik.http.services.vault.loadbalancer.server.scheme=https"
       }
       ui = true
       api_addr =  "http://${NODE_IP}:8200"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -5,7 +5,7 @@ nomad_drivers = ["docker", "raw_exec", "java"]
 nomad_server_ips = ["10.18.3.10", "10.18.3.11", "10.18.3.12"]
 nomad_server_enable_client = false
 nomad_server_vcpu = 1
-nomad_server_memory = 512
+nomad_server_memory = 1024
 nomad_server_disk_size = "4294965097" #4gb
 
 nomad_client_ips = ["10.18.3.20", "10.18.3.21"]

--- a/terraform/nomad-server.tf
+++ b/terraform/nomad-server.tf
@@ -102,3 +102,29 @@ resource "libvirt_domain" "domain-nomad-server" {
     ]
   }
 }
+
+resource "null_resource" "vault-init" {
+  depends_on = [
+    libvirt_domain.domain-nomad-server
+  ]
+
+  provisioner "local-exec" {
+    command = "curl --request PUT -k -d '{\"secret_shares\": 10, \"secret_threshold\": 5}' https://${element(var.nomad_server_ips, 0)}:8200/v1/sys/init > ${path.cwd}/vault.keys"
+  }
+}
+
+resource "null_resource" "vault-unseal" {
+  count  = length(var.nomad_server_ips)
+  depends_on = [
+    null_resource.vault-init
+  ]
+
+  provisioner "local-exec" {
+    command = "${path.cwd}/scripts/vault-unseal.sh"
+
+    environment = {
+      VAULT_IP = "${element(var.nomad_server_ips, count.index)}"
+      VAULT_KEYS = file("${path.cwd}/vault.keys")
+    }
+  }
+}

--- a/terraform/nomad-server.tf
+++ b/terraform/nomad-server.tf
@@ -124,7 +124,7 @@ resource "null_resource" "vault-unseal" {
 
     environment = {
       VAULT_IP = "${element(var.nomad_server_ips, count.index)}"
-      VAULT_KEYS = file("${path.cwd}/vault.keys")
+      VAULT_KEYS = "${path.cwd}/vault.keys"
     }
   }
 }


### PR DESCRIPTION
Vault has been installed on all servers in a vault cluster using Consul as backend. It also has tags that `Traefik` uses to expose Vault through `Traefik`. 

To enable Vault, you need to open each instance directly in a browser, run an init and unseal it. Once all are unsealed, it will be picked up by Traefik. If you have 3 servers in your setup, you should open:
```
https://10.18.3.10:8200/
https://10.18.3.11:8200/
https://10.18.3.12:8200/
```
Init the first and unseal, and then unseal the rest one by one.

To test the Vault ui through traefik, add a line to your `/etc/hosts` like this
```
10.18.3.11 vault.hashistack.local
```
Remember to change the ip to the ip of Traefik (check the deployment in Nomad).
Then acces Vault in a browser via  `https://vault.hashistack.local`

Traefik uses selfsigned certs, and Vault is also terminated with its own tls. So you browser will give you a warning.